### PR TITLE
Fix #1: 解决minted宏包字体问题并添加寻找不到字体时的Fallback策略

### DIFF
--- a/beamerthemegpark.sty
+++ b/beamerthemegpark.sty
@@ -69,15 +69,47 @@
 % 字体
 % TODO: 我是不是应该用 overleaf 上有的字体
 \setmainfont{Times New Roman} % 英文字体
-\setCJKmainfont{TsangerJinKai05} % 正文字体
-\setCJKsansfont{Source Han Serif CN} % 标题字体
-% TODO: minted 无法使用指定的等宽字体
-\setCJKmonofont{JetBrainsMono Nerd Font Mono} % 等宽字体
+% 正文字体
+\IfFontExistsTF{TsangerJinKai05}{
+  \setCJKmainfont{TsangerJinKai05}
+}{
+  \setCJKmainfont{FandolFang}
+}
+% 标题字体
+\IfFontExistsTF{Source Han Serif CN}{
+  \newCJKfontfamily{\sintefserif}{Source Han Serif CN}
+}{
+  \newCJKfontfamily{\sintefserif}{FandolSong}
+}
+% 为minted指定字体，顺序匹配：JetBrainsMono Nerd Font Mono -> Cascadia Code -> Consolas -> Courier New
+\IfFontExistsTF{JetBrainsMono Nerd Font Mono}{
+  \newfontfamily{\mintedcodefont}{JetBrainsMono Nerd Font Mono}[NFSSFamily=mintedcodefont]
+}{
+\IfFontExistsTF{Cascadia Code}{
+  \newfontfamily{\mintedcodefont}{Cascadia Code}[NFSSFamily=mintedcodefont]
+}{
+\IfFontExistsTF{Consolas}{
+  \newfontfamily{\mintedcodefont}{Consolas}[NFSSFamily=mintedcodefont]
+}{
+  \newfontfamily{\mintedcodefont}{Courier New}[NFSSFamily=mintedcodefont]
+}}}
+
+\setminted{
+  fontfamily=mintedcodefont,
+}
 \RequirePackage{amsfonts, amsmath, oldgerm, lmodern, bm} % 数学相关的字体
 \let\songti\relax
 \let\heiti\relax
-\setCJKfamilyfont{heiti}[AutoFakeBold = {2.17}]{Source Han Serif CN}
-\setCJKfamilyfont{hwxingkai}[AutoFakeBold = {2.17}]{STXingkai}
+\IfFontExistsTF{Source Han Serif CN}{
+  \setCJKfamilyfont{heiti}[AutoFakeBold = {2.17}]{Source Han Serif CN}
+}{
+  \setCJKfamilyfont{heiti}[AutoFakeBold = {2.17}]{FandolHei}
+}
+\IfFontExistsTF{STXingkai}{
+  \setCJKfamilyfont{hwxingkai}[AutoFakeBold = {2.17}]{STXingkai}
+}{
+  \setCJKfamilyfont{hwxingkai}[AutoFakeBold = {2.17}]{FandolKai}
+}
 \newcommand{\heiti}{\CJKfamily{heiti}}
 \newcommand{\hwxingkai}{\CJKfamily{hwxingkai}}
 

--- a/beamerthemegpark.sty
+++ b/beamerthemegpark.sty
@@ -67,7 +67,6 @@
 \setlength{\parindent}{2em} % 首行缩进 2 字符
 
 % 字体
-% TODO: 我是不是应该用 overleaf 上有的字体
 \setmainfont{Times New Roman} % 英文字体
 % 正文字体
 \IfFontExistsTF{TsangerJinKai05}{


### PR DESCRIPTION
## 解决minted使用自定义字体问题
Fix #1 .

如果直接`/newfontfamily/mintedcodefont{Consolas}`，那么minted会报"Font shape TU/mintedcodefont/m/n' undefined"

翻到 https://github.com/gpoore/minted/issues/365 指出：
> minted uses fancyvrb to typeset the code. The fontspec manual gives an example using fancyvrb, and in the \newfontfamily definition uses the equivalent of NFSSFamily=inconsolata. I'd suggest starting there. （https://github.com/gpoore/minted/issues/365#issuecomment-1517794111）

因此此PR主要添加一行NFSSFamily=mintedcodefont，解决了自定义fontfamily失效的问题

## 添加默认字体Fallback策略

此外，优于原作者采用了部分生僻字体，因此不一定所有人都有安装在自己的电脑上，因此添加了找不到目标字体时Fallback到一个覆盖率更高些的字体上的策略，基于`\IfFontExistsTF`实现

这样既不影响喜欢这些字体的原作者，也不影响没有这些字体的普罗大众和Overleaf，再也不用为后者特殊关照辣